### PR TITLE
Update: Bump go-yaml to latest v2 version and ignore coverage file

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -19,8 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.15
+          - 1.17
           - 1.16
+          - 1.15
     steps:
       - uses: actions/checkout@v2
 
@@ -28,10 +29,23 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: setup-for-go-115
+        if: ${{ matrix.go == 1.15 }}
+        run: |
+          # stay on an old version of golangci-lint which still builds against 1.15
+          #
+          # see release notes and this file for detail:
+          # https://github.com/golangci/golangci-lint/blob/v1.43.0/.github/workflows/pr.yml#L67-70
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+
+      - name: setup-for-new-go
+        if: ${{ matrix.go != 1.15 }}
+        run: |
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
       - name: setup
         run: |
           go version
-          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           go get github.com/securego/gosec/cmd/gosec
           #go get golang.org/x/tools/cmd/cover
           go get github.com/axw/gocov/gocov

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -50,6 +50,7 @@ jobs:
           #go get golang.org/x/tools/cmd/cover
           go get github.com/axw/gocov/gocov
           go get github.com/AlekSi/gocov-xml
+          git checkout go.mod go.sum
 
       - name: build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 */debug
 vendor
 *.cover
+coverage.xml
 Gopkg.lock
 cmd/rego/rego
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint:
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \
-		--enable=golint \
+		--enable=revive \
 		--enable=unused \
 		--enable=structcheck \
 		--enable=staticcheck \

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 	gopkg.in/ini.v1 v1.57.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -391,8 +391,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
#### Description
This bumps the go-yaml version to the latest v2 version (v2.4.0). The reason for this is that there was a line wrapping introduction in v2.3.0 that was causing discrepancies between OS flavors. It was subsequently reverted here: https://github.com/go-yaml/yaml/releases/tag/v2.4.0

This solves the problem by properly wrapping lines to a reasonable size once again for all lines in a yaml. The also brings back consistency between the regolithe extension in vscode and command line execution.